### PR TITLE
Ændringer til bedre exception håndtering i loadSeeds

### DIFF
--- a/webdanica-core/pom.xml
+++ b/webdanica-core/pom.xml
@@ -68,13 +68,22 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.apache.phoenix/phoenix-core -->
     <dependency>
-      <groupId>phoenix-hbase</groupId>
-      <artifactId>phoenix-HBase</artifactId>
-      <version>4.7.0-1.1</version>
-      <scope>system</scope>
-      <systemPath>${basedir}/lib/phoenix-4.7.0-HBase-1.1-client.jar</systemPath>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-core</artifactId>
+      <version>4.7.0-HBase-1.1</version>
+      <scope>provided</scope>
     </dependency>
+
+    <!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>2.7.2</version>
+      <scope>provided</scope>
+    </dependency>
+
 
     <dependency>
       <groupId>xerces</groupId>

--- a/webdanica-core/src/main/java/dk/kb/webdanica/core/datamodel/dao/DAOFactory.java
+++ b/webdanica-core/src/main/java/dk/kb/webdanica/core/datamodel/dao/DAOFactory.java
@@ -1,7 +1,7 @@
 package dk.kb.webdanica.core.datamodel.dao;
 
 
-public interface DAOFactory {
+public interface DAOFactory extends AutoCloseable {
 
 	public SeedsDAO getSeedsDAO();
 	

--- a/webdanica-core/src/main/java/dk/kb/webdanica/core/datamodel/dao/DaoException.java
+++ b/webdanica-core/src/main/java/dk/kb/webdanica/core/datamodel/dao/DaoException.java
@@ -1,0 +1,26 @@
+package dk.kb.webdanica.core.datamodel.dao;
+
+/**
+ * Created by abr on 7/27/17.
+ */
+public class DaoException extends Exception {
+
+    public DaoException() {
+    }
+
+    public DaoException(String message) {
+        super(message);
+    }
+
+    public DaoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DaoException(Throwable cause) {
+        super(cause);
+    }
+
+    public DaoException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/webdanica-core/src/main/java/dk/kb/webdanica/core/datamodel/dao/DomainsDAO.java
+++ b/webdanica-core/src/main/java/dk/kb/webdanica/core/datamodel/dao/DomainsDAO.java
@@ -6,21 +6,21 @@ import java.util.Set;
 import dk.kb.webdanica.core.datamodel.DanicaStatus;
 import dk.kb.webdanica.core.datamodel.Domain;
 
-public interface DomainsDAO {
+public interface DomainsDAO extends AutoCloseable{
 
-	boolean insertDomain(Domain singleSeed) throws Exception;
+	boolean insertDomain(Domain singleSeed) throws DaoException;
 
-	List<Domain> getDomains(DanicaStatus status, String tld, int limit) throws Exception;
+	List<Domain> getDomains(DanicaStatus status, String tld, int limit) throws DaoException;
 	
-	Domain getDomain(String domain) throws Exception;
+	Domain getDomain(String domain) throws DaoException;
 
 	void close();
 
-	Long getDomainsCount(DanicaStatus status, String tld) throws Exception;
+	Long getDomainsCount(DanicaStatus status, String tld) throws DaoException;
 
-	boolean existsDomain(String domain) throws Exception;
+	boolean existsDomain(String domain) throws DaoException;
 
-	boolean update(Domain d) throws Exception;
+	boolean update(Domain d) throws DaoException;
 
-	Set<String> getTlds() throws Exception;
+	Set<String> getTlds() throws DaoException;
 }

--- a/webdanica-core/src/main/java/dk/kb/webdanica/core/datamodel/dao/HBasePhoenixCriteriaResultsDAO.java
+++ b/webdanica-core/src/main/java/dk/kb/webdanica/core/datamodel/dao/HBasePhoenixCriteriaResultsDAO.java
@@ -3,17 +3,19 @@ package dk.kb.webdanica.core.datamodel.dao;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
 
-import org.apache.calcite.avatica.SqlType;
 import org.apache.commons.lang.StringUtils;
 
 import dk.kb.webdanica.core.utils.DatabaseUtils;
 import dk.kb.webdanica.core.datamodel.criteria.DataSource;
 import dk.kb.webdanica.core.datamodel.criteria.SingleCriteriaResult;
+
+import static java.sql.JDBCType.BIGINT;
 
 public class HBasePhoenixCriteriaResultsDAO implements CriteriaResultsDAO {
 	
@@ -120,19 +122,19 @@ public class HBasePhoenixCriteriaResultsDAO implements CriteriaResultsDAO {
 			stm.setString(idx++, singleAnalysis.errorMsg);
 			
 			if (singleAnalysis.Cext1 == null) {
-				stm.setNull(idx, SqlType.BIGINT.id);
+				stm.setNull(idx, Types.BIGINT);
 			} else {
 				stm.setLong(idx, singleAnalysis.Cext1);
 			}
 			idx++;
 			if (singleAnalysis.Cext2 == null) {
-				stm.setNull(idx, SqlType.BIGINT.id);
+				stm.setNull(idx, Types.BIGINT);
 			} else {
 				stm.setLong(idx, singleAnalysis.Cext2);
 			}
 			idx++;
 			if (singleAnalysis.Cext3 == null) {
-				stm.setNull(idx, SqlType.BIGINT.id);
+				stm.setNull(idx, Types.BIGINT);
 			} else {
 				stm.setLong(idx, singleAnalysis.Cext3);
 			}
@@ -142,7 +144,7 @@ public class HBasePhoenixCriteriaResultsDAO implements CriteriaResultsDAO {
 			}
 			stm.setFloat(idx++, singleAnalysis.intDanish);
 			if (singleAnalysis.source == null) {
-				stm.setNull(idx, SqlType.BIGINT.id);
+				stm.setNull(idx, Types.BIGINT);
 			} else {
 				stm.setInt(idx, singleAnalysis.source.ordinal());
 			}

--- a/webdanica-core/src/main/java/dk/kb/webdanica/core/datamodel/dao/HBasePhoenixSeedsDAO.java
+++ b/webdanica-core/src/main/java/dk/kb/webdanica/core/datamodel/dao/HBasePhoenixSeedsDAO.java
@@ -1,153 +1,144 @@
 package dk.kb.webdanica.core.datamodel.dao;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.LinkedList;
 import java.util.List;
 
 import dk.kb.webdanica.core.datamodel.DanicaStatus;
 import dk.kb.webdanica.core.datamodel.Seed;
 import dk.kb.webdanica.core.datamodel.Status;
+import dk.kb.webdanica.core.utils.CloseUtils;
 
 public class HBasePhoenixSeedsDAO implements SeedsDAO {
 
-	private static final String UPSERT_SQL;
+    private static final String UPSERT_SQL;
 
-	private static final String EXISTS_SQL;
-	
-	/*
-			url VARCHAR PRIMARY KEY,
-		    redirected_url VARCHAR,
-		    host VARCHAR(256),
-		    domain VARCHAR(256),
-		    tld VARCHAR(64) // Top level domain for this seed
-		    inserted_time TIMESTAMP,
-		    updated_time TIMESTAMP,
-   		    danica INTEGER, // see dk.kb.webdanica.datamodel.DanicaStatus enum class
-		    status INTEGER, // see dk.kb.webdanica.datamodel.Status enum class
-		    status_reason VARCHAR, // textual explanation behind its state
-		    exported boolean,
-		    exported_time TIMESTAMP,
-		    danica_reason VARCHAR
-		    
-	*/
-	static {
-		UPSERT_SQL = ""
-				+ "UPSERT INTO seeds (url, redirected_url, host, domain, tld, inserted_time, updated_time, danica, status, status_reason, exported, exported_time, danica_reason) "
-				+ "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?) ";
-		
-		EXISTS_SQL = ""
-		        + "SELECT count(*) "
+    private static final String EXISTS_SQL;
+
+    /*
+            url VARCHAR PRIMARY KEY,
+            redirected_url VARCHAR,
+            host VARCHAR(256),
+            domain VARCHAR(256),
+            tld VARCHAR(64) // Top level domain for this seed
+            inserted_time TIMESTAMP,
+            updated_time TIMESTAMP,
+               danica INTEGER, // see dk.kb.webdanica.datamodel.DanicaStatus enum class
+            status INTEGER, // see dk.kb.webdanica.datamodel.Status enum class
+            status_reason VARCHAR, // textual explanation behind its state
+            exported boolean,
+            exported_time TIMESTAMP,
+            danica_reason VARCHAR
+
+    */
+    static {
+        UPSERT_SQL = ""
+                + "UPSERT INTO seeds (url, redirected_url, host, domain, tld, inserted_time, updated_time, danica, status, status_reason, exported, exported_time, danica_reason) "
+                + "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?) ";
+
+        EXISTS_SQL = ""
+                + "SELECT count(*) "
                 + "FROM seeds "
-                + "WHERE url=? ";	
-	}
+                + "WHERE url=? ";
+    }
 
-	@Override
-	public boolean insertSeed(Seed singleSeed) throws Exception {
-	    if (existsUrl(singleSeed.getUrl())) {
-	        return false;
-	    }
-	    return upsertSeed(singleSeed, true);
-		
-	}
-	
-	private boolean upsertSeed(Seed singleSeed, boolean isInsert) throws Exception {
-		PreparedStatement stm = null;
-		int res = 0;
-		Long now = System.currentTimeMillis();
-		Long updatedTime = now;
-		Long insertedTime = null;
-		Long exportedTime = null;
-		if (singleSeed.getExportedState() == true && singleSeed.getExportedTime() == null) {
-			exportedTime = now;
-		}
-		Timestamp exportedTimeAsTimestamp = null;
-		if (exportedTime != null) {
-			exportedTimeAsTimestamp = new Timestamp(exportedTime);
-		}
-		if (isInsert) {
-			insertedTime = now;
-		} else {
-			insertedTime = singleSeed.getInsertedTime();
-		}
-		
-		try {
-			Connection conn = HBasePhoenixConnectionManager.getThreadLocalConnection();
-			stm = conn.prepareStatement(UPSERT_SQL);
-			stm.clearParameters();
-			stm.setString(1, singleSeed.getUrl());
-			stm.setString(2, singleSeed.getRedirectedUrl());
-			stm.setString(3, singleSeed.getHostname());
-			stm.setString(4, singleSeed.getDomain());
-			stm.setString(5, singleSeed.getTld());
-			stm.setTimestamp(6, new Timestamp(insertedTime));
-			stm.setTimestamp(7, new Timestamp(updatedTime));
-			stm.setInt(8, singleSeed.getDanicaStatus().ordinal());
-			stm.setInt(9, singleSeed.getStatus().ordinal());
-			stm.setString(10, singleSeed.getStatusReason());
-			stm.setBoolean(11, singleSeed.getExportedState());
-			stm.setTimestamp(12, exportedTimeAsTimestamp);
-			stm.setString(13, singleSeed.getDanicaStatusReason());
-			res = stm.executeUpdate();
-			conn.commit();
-		} finally {
-			if (stm != null) {
-				stm.close();
-			}
-		}
-		return res != 0;
-	}
-	
-	
-	
-	@Override
-	public boolean existsUrl(String url) throws Exception {
-	    PreparedStatement stm = null;
-        ResultSet rs = null;
+    @Override
+    public boolean insertSeed(Seed singleSeed) throws DaoException {
+        if (existsUrl(singleSeed.getUrl())) {
+            return false;
+        }
+        return upsertSeed(singleSeed, true);
+
+    }
+
+    private boolean upsertSeed(Seed singleSeed, boolean isInsert) throws DaoException {
+        int res = 0;
+        Long now = System.currentTimeMillis();
+        Long updatedTime = now;
+        Long insertedTime;
+        Long exportedTime = null;
+        if (singleSeed.getExportedState() && singleSeed.getExportedTime() == null) {
+            exportedTime = now;
+        }
+        Timestamp exportedTimeAsTimestamp = null;
+        if (exportedTime != null) {
+            exportedTimeAsTimestamp = new Timestamp(exportedTime);
+        }
+        if (isInsert) {
+            insertedTime = now;
+        } else {
+            insertedTime = singleSeed.getInsertedTime();
+        }
+
+        try {
+            Connection conn = HBasePhoenixConnectionManager.getThreadLocalConnection();
+            try (PreparedStatement stm = conn.prepareStatement(UPSERT_SQL);) {
+                stm.clearParameters();
+                stm.setString(1, singleSeed.getUrl());
+                stm.setString(2, singleSeed.getRedirectedUrl());
+                stm.setString(3, singleSeed.getHostname());
+                stm.setString(4, singleSeed.getDomain());
+                stm.setString(5, singleSeed.getTld());
+                stm.setTimestamp(6, new Timestamp(insertedTime));
+                stm.setTimestamp(7, new Timestamp(updatedTime));
+                stm.setInt(8, singleSeed.getDanicaStatus().ordinal());
+                stm.setInt(9, singleSeed.getStatus().ordinal());
+                stm.setString(10, singleSeed.getStatusReason());
+                stm.setBoolean(11, singleSeed.getExportedState());
+                stm.setTimestamp(12, exportedTimeAsTimestamp);
+                stm.setString(13, singleSeed.getDanicaStatusReason());
+                res = stm.executeUpdate();
+                conn.commit();
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        }
+        return res != 0;
+    }
+
+
+    @Override
+    public boolean existsUrl(String url) throws DaoException {
         long res = 0;
         try {
             Connection conn = HBasePhoenixConnectionManager.getThreadLocalConnection();
-            stm = conn.prepareStatement(EXISTS_SQL);
-            stm.clearParameters();
-            stm.setString(1, url);
-            rs = stm.executeQuery();
-            if (rs != null && rs.next()) {
-                res = rs.getLong(1);
+            try (PreparedStatement stm = conn.prepareStatement(EXISTS_SQL);) {
+                stm.clearParameters();
+                stm.setString(1, url);
+                try (ResultSet rs = stm.executeQuery();) {
+                    if (rs != null && rs.next()) {
+                        res = rs.getLong(1);
+                    }
+                }
             }
-        } finally {
-            if (rs != null) {
-                rs.close();
-            }
-            if (stm != null) {
-                stm.close();
-            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
         }
         return res != 0L;
-	}
+    }
 
-	
-	@Override
-	public boolean updateSeed(Seed singleSeed) throws Exception {
-		return upsertSeed(singleSeed, false);
-	}
 
-	
-	private static final String SEEDS_COUNT_BY_STATUS_SQL;
-	private static final String SEEDS_COUNT_ALL_SQL;
-	static {
-		SEEDS_COUNT_BY_STATUS_SQL = ""
-				+ "SELECT count(*) "
-				+ "FROM seeds "
-				+ "WHERE status=? ";
-		SEEDS_COUNT_ALL_SQL = ""
+    @Override
+    public boolean updateSeed(Seed singleSeed) throws DaoException {
+        return upsertSeed(singleSeed, false);
+    }
+
+
+    private static final String SEEDS_COUNT_BY_STATUS_SQL;
+    private static final String SEEDS_COUNT_ALL_SQL;
+
+    static {
+        SEEDS_COUNT_BY_STATUS_SQL = ""
+                + "SELECT count(*) "
+                + "FROM seeds "
+                + "WHERE status=? ";
+        SEEDS_COUNT_ALL_SQL = ""
                 + "SELECT count(*) "
                 + "FROM seeds ";
-	}
+    }
 
 	@Override
-	public Long getSeedsCount(Status status) throws Exception {
+	public Long getSeedsCount(Status status) throws DaoException {
 		PreparedStatement stm = null;
 		ResultSet rs = null;
 		long res = 0;
@@ -165,113 +156,102 @@ public class HBasePhoenixSeedsDAO implements SeedsDAO {
 			if (rs != null && rs.next()) {
 				res = rs.getLong(1);
 			}
-		} finally {
-			if (rs != null) {
-				rs.close();
-			}
-			if (stm != null) {
-				stm.close();
-			}
+		} catch (SQLException e) {
+            throw new DaoException(e);
+        } finally {
+            CloseUtils.closeQuietly(stm);
+            CloseUtils.closeQuietly(rs);
 		}
 		return res;
 	}	
 
-	private static final String SEEDS_BY_STATUS_SQL;
+    private static final String SEEDS_BY_STATUS_SQL;
 
-	static {
-		SEEDS_BY_STATUS_SQL = "SELECT * "
-				+ "FROM seeds "
-				+ "WHERE status=? LIMIT ?";
-	}
+    static {
+        SEEDS_BY_STATUS_SQL = "SELECT * "
+                + "FROM seeds "
+                + "WHERE status=? LIMIT ?";
+    }
 
-	@Override
-	public List<Seed> getSeeds(Status status, int limit) throws Exception {
-		List<Seed> seedList = new LinkedList<Seed>();
-		PreparedStatement stm = null;
-		ResultSet rs = null;
-		try {
-			Connection conn = HBasePhoenixConnectionManager.getThreadLocalConnection();
-			stm = conn.prepareStatement(SEEDS_BY_STATUS_SQL);
-			stm.clearParameters();
-			stm.setInt(1, status.ordinal());
-			stm.setInt(2, limit);
-			rs = stm.executeQuery();
-			if (rs != null) {
-				while (rs.next()) {
-					seedList.add(getSeedFromResultSet(rs));
-				}
-			}
-		} finally {
-			if (rs != null) {
-				rs.close();
-			}
-			if (stm != null) {
-				stm.close();
-			}
-		}
-		return seedList; 
-	}
+    @Override
+    public List<Seed> getSeeds(Status status, int limit) throws DaoException {
+        List<Seed> seedList = new LinkedList<Seed>();
+        try {
+            Connection conn = HBasePhoenixConnectionManager.getThreadLocalConnection();
+            try (PreparedStatement stm = conn.prepareStatement(SEEDS_BY_STATUS_SQL);) {
+                stm.clearParameters();
+                stm.setInt(1, status.ordinal());
+                stm.setInt(2, limit);
+                try (ResultSet rs = stm.executeQuery();) {
+                    if (rs != null) {
+                        while (rs.next()) {
+                            seedList.add(getSeedFromResultSet(rs));
+                        }
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        }
+        return seedList;
+    }
 
-	private Seed getSeedFromResultSet(ResultSet rs) throws Exception {
-		Timestamp t = rs.getTimestamp("exported_time");
-		Long exportedTime = null;
-		if (t != null) {
-			exportedTime = t.getTime();
-		}
-		return new Seed(
-				rs.getString("url"),
-				rs.getString("redirected_url"), 
-				rs.getString("host"),
-				rs.getString("domain"),
-				rs.getString("tld"),
-				rs.getTimestamp("inserted_time").getTime(),
-				rs.getTimestamp("updated_time").getTime(),
-				DanicaStatus.fromOrdinal(rs.getInt("danica")),
-				Status.fromOrdinal(rs.getInt("status")), 
-				rs.getString("status_reason"),
-				rs.getBoolean("exported"),
-				exportedTime, 
-				rs.getString("danica_reason")
-				);
-	}	
-	
-	@Override
-	public void close() {
-	}
+    private Seed getSeedFromResultSet(ResultSet rs) throws SQLException {
+        Timestamp t = rs.getTimestamp("exported_time");
+        Long exportedTime = null;
+        if (t != null) {
+            exportedTime = t.getTime();
+        }
+        return new Seed(
+                rs.getString("url"),
+                rs.getString("redirected_url"),
+                rs.getString("host"),
+                rs.getString("domain"),
+                rs.getString("tld"),
+                rs.getTimestamp("inserted_time").getTime(),
+                rs.getTimestamp("updated_time").getTime(),
+                DanicaStatus.fromOrdinal(rs.getInt("danica")),
+                Status.fromOrdinal(rs.getInt("status")),
+                rs.getString("status_reason"),
+                rs.getBoolean("exported"),
+                exportedTime,
+                rs.getString("danica_reason")
+        );
+    }
 
-	private static final String SELECT_COUNT_DANICA_SQL;
+    @Override
+    public void close() {
+    }
 
-	static {
-		SELECT_COUNT_DANICA_SQL = ""
-				+ "SELECT COUNT(*) FROM seeds WHERE danica=?";
-	}
+    private static final String SELECT_COUNT_DANICA_SQL;
 
-	@Override
-    public Long getSeedsDanicaCount(DanicaStatus s) throws Exception {
-		if (s == null)  {
-			return 0L;
-		}
-		PreparedStatement stm = null;
-		ResultSet rs = null;
-		long res = 0;
-		try {
-			Connection conn = HBasePhoenixConnectionManager.getThreadLocalConnection();
-			stm = conn.prepareStatement(SELECT_COUNT_DANICA_SQL);
-			stm.clearParameters();
-			stm.setInt(1, s.ordinal());
-			rs = stm.executeQuery();
-			if (rs != null && rs.next()) {
-				res = rs.getLong(1);
-			}
-		} finally {
-			if (rs != null) {
-				rs.close();
-			}
-			if (stm != null) {
-				stm.close();
-			}
-		}
-		return res;
+    static {
+        SELECT_COUNT_DANICA_SQL = ""
+                + "SELECT COUNT(*) FROM seeds WHERE danica=?";
+    }
+
+    @Override
+    public Long getSeedsDanicaCount(DanicaStatus s) throws DaoException {
+        if (s == null) {
+            return 0L;
+        }
+        long res = 0;
+        try {
+            Connection conn = HBasePhoenixConnectionManager.getThreadLocalConnection();
+            try (PreparedStatement stm = conn.prepareStatement(SELECT_COUNT_DANICA_SQL);) {
+                stm.clearParameters();
+                stm.setInt(1, s.ordinal());
+                try (ResultSet rs = stm.executeQuery();) {
+                    if (rs != null && rs.next()) {
+                        res = rs.getLong(1);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        }
+
+        return res;
     }
 
 	private static final String SEEDS_READY_TO_EXPORT_SQL;
@@ -286,7 +266,7 @@ public class HBasePhoenixSeedsDAO implements SeedsDAO {
 	}
 	
 	@Override
-    public List<Seed> getSeedsReadyToExport(boolean includeAlreadyExported) throws Exception {
+    public List<Seed> getSeedsReadyToExport(boolean includeAlreadyExported) throws DaoException {
 		//DanicaStatus==YES && exported==false && status==DONE  // Seed kan også have DanicaStatus=YES, men have Status REJECTED, hvis domænet allerede er danica
 		List<Seed> seedList = new LinkedList<Seed>();
 		PreparedStatement stm = null;
@@ -314,52 +294,45 @@ public class HBasePhoenixSeedsDAO implements SeedsDAO {
 					seedList.add(getSeedFromResultSet(rs));
 				}
 			}
-		} finally {
-			if (rs != null) {
-				rs.close();
-			}
-			if (stm != null) {
-				stm.close();
-			}
+		} catch (SQLException e) {
+            throw new DaoException(e);
+        } finally {
+		    CloseUtils.closeQuietly(rs);
+		    CloseUtils.closeQuietly(stm);
 		}
 		return seedList; 			   
     }
 
-	
-	private static final String SEED_SELECT_SQL;
 
-	static {
-		SEED_SELECT_SQL = "SELECT * "
-				+ "FROM seeds "
-				+ "WHERE url=?";
-	}
+    private static final String SEED_SELECT_SQL;
 
-	
-	@Override
-    public Seed getSeed(String url) throws Exception {
-		if (!existsUrl(url)) {
-	        return null;
-	    }
-		PreparedStatement stm = null;
-		ResultSet rs = null;
-		Seed result = null;
-		try {
-			Connection conn = HBasePhoenixConnectionManager.getThreadLocalConnection();
-			stm = conn.prepareStatement(SEED_SELECT_SQL);
-			stm.clearParameters();
-			stm.setString(1, url);
-			rs = stm.executeQuery();
-			if (rs != null && rs.next()) {
-				result = getSeedFromResultSet(rs);
-			}
-		} finally {
-			if (rs != null) {
-				rs.close();
-			}
-			if (stm != null) {
-				stm.close();
-			}
-		}				
-	    return result;
+    static {
+        SEED_SELECT_SQL = "SELECT * "
+                + "FROM seeds "
+                + "WHERE url=?";
+    }
+
+
+    @Override
+    public Seed getSeed(String url) throws DaoException {
+        if (!existsUrl(url)) {
+            return null;
+        }
+        Seed result = null;
+        try {
+            Connection conn = HBasePhoenixConnectionManager.getThreadLocalConnection();
+            try (PreparedStatement stm = conn.prepareStatement(SEED_SELECT_SQL);) {
+                stm.clearParameters();
+                stm.setString(1, url);
+                try (ResultSet rs = stm.executeQuery();) {
+                    if (rs != null && rs.next()) {
+                        result = getSeedFromResultSet(rs);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        }
+        return result;
     }
 }

--- a/webdanica-core/src/main/java/dk/kb/webdanica/core/datamodel/dao/SeedsDAO.java
+++ b/webdanica-core/src/main/java/dk/kb/webdanica/core/datamodel/dao/SeedsDAO.java
@@ -6,25 +6,25 @@ import dk.kb.webdanica.core.datamodel.DanicaStatus;
 import dk.kb.webdanica.core.datamodel.Seed;
 import dk.kb.webdanica.core.datamodel.Status;
 
-public interface SeedsDAO {
+public interface SeedsDAO extends AutoCloseable{
 
-	boolean insertSeed(Seed singleSeed) throws Exception;	
+	boolean insertSeed(Seed singleSeed) throws DaoException;
 	
-	boolean updateSeed(Seed singleSeed) throws Exception;
+	boolean updateSeed(Seed singleSeed) throws DaoException;
 	
-	List<Seed> getSeeds(Status fromOrdinal, int limit) throws Exception;
+	List<Seed> getSeeds(Status fromOrdinal, int limit) throws DaoException;
 
-	Long getSeedsCount(Status fromOrdinal) throws Exception;
+	Long getSeedsCount(Status fromOrdinal) throws DaoException;
 	
 	void close();
 
-	Long getSeedsDanicaCount(DanicaStatus s) throws Exception;
+	Long getSeedsDanicaCount(DanicaStatus s) throws DaoException;
 
-	List<Seed> getSeedsReadyToExport(boolean includeAlreadyExportedSeeds) throws Exception;
+	List<Seed> getSeedsReadyToExport(boolean includeAlreadyExportedSeeds) throws DaoException;
 
-	boolean existsUrl(String url) throws Exception;
+	boolean existsUrl(String url) throws DaoException;
 	
-	Seed getSeed(String url)  throws Exception;
+	Seed getSeed(String url)  throws DaoException;
 }
 	
 	

--- a/webdanica-core/src/main/java/dk/kb/webdanica/core/tools/LoadSeeds.java
+++ b/webdanica-core/src/main/java/dk/kb/webdanica/core/tools/LoadSeeds.java
@@ -1,15 +1,11 @@
 package dk.kb.webdanica.core.tools;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.PrintWriter;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import dk.kb.webdanica.core.datamodel.dao.*;
 import org.apache.commons.io.IOUtils;
 
 import dk.kb.webdanica.core.datamodel.DanicaStatus;
@@ -18,368 +14,376 @@ import dk.kb.webdanica.core.datamodel.IngestLog;
 import dk.kb.webdanica.core.datamodel.Seed;
 import dk.kb.webdanica.core.datamodel.Status;
 import dk.kb.webdanica.core.datamodel.URL_REJECT_REASON;
-import dk.kb.webdanica.core.datamodel.dao.DAOFactory;
-import dk.kb.webdanica.core.datamodel.dao.DomainsDAO;
-import dk.kb.webdanica.core.datamodel.dao.IngestLogDAO;
-import dk.kb.webdanica.core.datamodel.dao.SeedsDAO;
 import dk.kb.webdanica.core.utils.DatabaseUtils;
 import dk.kb.webdanica.core.utils.UrlUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Program to load seeds into the webdanica database.
- * Policy: 
- *  - Seeds already present in the database is ignored
- *  - seeds that are not proper URLs are not loaded into the database
- *  - seeds that have extensions matching any of the suffixes in our ignored suffixes are also skipped
- *  
- *  Remember to call program with -Dwebdanica.settings.file=$LOADSEEDS_HOME/webdanica_settings_file
- *  and -Ddk.netarkivet.settings.file=$LOADSEEDS_HOME/settings_NAS_Webdanica.xml
- *  and -Dlogback.configurationFile=$LOADSEEDS_HOME/silent_logback.xml 
- *  
- *  TESTED with webdanica-core/src/main/resources/outlink-reportfile-final-1460549754730.txt
- *  TESTED with webdanica-core/src/main/resources/outlinksWithAnnotations.txt
- *  TESTED with webdanica-core/src/main/resources/webdanica-seeds.table
+ * Policy:
+ * - Seeds already present in the database is ignored
+ * - seeds that are not proper URLs are not loaded into the database
+ * - seeds that have extensions matching any of the suffixes in our ignored suffixes are also skipped
+ * <p>
+ * Remember to call program with -Dwebdanica.settings.file=$LOADSEEDS_HOME/webdanica_settings_file
+ * and -Ddk.netarkivet.settings.file=$LOADSEEDS_HOME/settings_NAS_Webdanica.xml
+ * and -Dlogback.configurationFile=$LOADSEEDS_HOME/silent_logback.xml
+ * <p>
+ * TESTED with webdanica-core/src/main/resources/outlink-reportfile-final-1460549754730.txt
+ * TESTED with webdanica-core/src/main/resources/outlinksWithAnnotations.txt
+ * TESTED with webdanica-core/src/main/resources/webdanica-seeds.table
  */
 public class LoadSeeds {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
+    public static final String ACCEPT_ARGUMENT = "--accepted";
+    public static final String ONLYSAVESTATS_ARGUMENT = "--onlysavestats";
 
-public static final String ACCEPT_ARGUMENT	= "--accepted";
-public static final String ONLYSAVESTATS_ARGUMENT = "--onlysavestats";
-	
-public static void main(String[] args) throws Exception {
-		boolean acceptSeedsAsDanica = false;
+    public static void main(String[] args) throws Exception {
+        boolean acceptSeedsAsDanica = false;
         if (args.length < 1 || args.length > 3) {
-        	System.err.println("Wrong number of arguments. One or two is needed. Given was " + args.length + " arguments");
+            System.err.println("Wrong number of arguments. One or two is needed. Given was " + args.length + " arguments");
             System.err.println("Correct usage: java LoadSeeds seedsfile [--accepted][--onlysavestats]");
             System.err.println("Exiting program");
             System.exit(1);
         }
         File seedsfile = new File(args[0]);
-        if (!seedsfile.isFile()){
+        if (!seedsfile.isFile()) {
             System.err.println("The seedsfile located '" + seedsfile.getAbsolutePath() + "' does not exist or is not a proper file");
             System.err.println("Exiting program");
             System.exit(1);
         }
         boolean onlysavestats = false;
         if (args.length > 1) { // parse optional arguments
-        	String arg2 = null;
-        	String arg3 = null;
-        	if (args.length == 2) {
-        		 arg2 = args[1];
-        	} else if (args.length == 3) {
-        		arg2 = args[1];
-        		arg3 = args[2];
-        	}
-        	if (arg2.equalsIgnoreCase(ACCEPT_ARGUMENT)) {
-        		acceptSeedsAsDanica = true;
-        	} else if (arg2.equalsIgnoreCase(ONLYSAVESTATS_ARGUMENT)) {
-        		onlysavestats = true;
-        	} else {
-        		System.err.println("The second argument '" + arg2 + "' is unknown. Don't know what to do. Exiting program");
-        		System.exit(1);
-        	}
-        	if (arg3 != null) {
-        		if (arg3.equalsIgnoreCase(ACCEPT_ARGUMENT)) {
-            		acceptSeedsAsDanica = true;
-            	} else if (arg3.equalsIgnoreCase(ONLYSAVESTATS_ARGUMENT)) {
-            		onlysavestats = true;
-            	} else {
-            		System.err.println("The third argument '" + arg3 + "' is unknown. Don't know what to do. Exiting program");
-            		System.exit(1);
-            	}
-        	}
-        } 
-        
+            String arg2 = null;
+            String arg3 = null;
+            if (args.length == 2) {
+                arg2 = args[1];
+            } else if (args.length == 3) {
+                arg2 = args[1];
+                arg3 = args[2];
+            }
+            if (arg2.equalsIgnoreCase(ACCEPT_ARGUMENT)) {
+                acceptSeedsAsDanica = true;
+            } else if (arg2.equalsIgnoreCase(ONLYSAVESTATS_ARGUMENT)) {
+                onlysavestats = true;
+            } else {
+                System.err.println("The second argument '" + arg2 + "' is unknown. Don't know what to do. Exiting program");
+                System.exit(1);
+            }
+            if (arg3 != null) {
+                if (arg3.equalsIgnoreCase(ACCEPT_ARGUMENT)) {
+                    acceptSeedsAsDanica = true;
+                } else if (arg3.equalsIgnoreCase(ONLYSAVESTATS_ARGUMENT)) {
+                    onlysavestats = true;
+                } else {
+                    System.err.println("The third argument '" + arg3 + "' is unknown. Don't know what to do. Exiting program");
+                    System.exit(1);
+                }
+            }
+        }
+
         System.out.println("Processing seeds from file '" + seedsfile.getAbsolutePath() + "'");
         if (acceptSeedsAsDanica) {
-        	System.out.println("Ingesting all seeds as danica!");
+            System.out.println("Ingesting all seeds as danica!");
         }
         if (onlysavestats) {
-        	System.out.println("Only saving statistics for the ingest. No update and reject information preserved!");
+            System.out.println("Only saving statistics for the ingest. No update and reject information preserved!");
         }
-        
+
         System.out.println();
         LoadSeeds loadseeds = new LoadSeeds(seedsfile, acceptSeedsAsDanica);
         loadseeds.writeAcceptLog = true;
         loadseeds.writeRejectLog = true;
         loadseeds.writeUpdateLog = true;
         loadseeds.onlysavestats = true;
-        
-        
+
+
         IngestLog res = loadseeds.processSeeds();
         System.out.println(res.getStatistics());
         File acceptLog = loadseeds.getAcceptLog();
         File rejectLog = loadseeds.getRejectLog();
         File updateLog = loadseeds.getUpdateLog();
-        System.out.println("Acceptlog in file: " + (acceptLog==null?"No log written due to error": acceptLog.getAbsolutePath()));
-        System.out.println("Rejectlog in file: " + (rejectLog==null?"No log written due to error": rejectLog.getAbsolutePath())); 
-        System.out.println("Updatelog in file: " + (updateLog==null?"No log written due to error": updateLog.getAbsolutePath()));
-        
+        System.out.println("Acceptlog in file: " + (acceptLog == null ? "No log written due to error" : acceptLog.getAbsolutePath()));
+        System.out.println("Rejectlog in file: " + (rejectLog == null ? "No log written due to error" : rejectLog.getAbsolutePath()));
+        System.out.println("Updatelog in file: " + (updateLog == null ? "No log written due to error" : updateLog.getAbsolutePath()));
+
     }
- 	
-	private File seedsfile;
+
+    private File seedsfile;
     private boolean writeAcceptLog = false;
     private boolean writeRejectLog = false;
     private boolean writeUpdateLog = false;
-	private File rejectLog = null;
-	private File acceptLog = null;
-	private File updateLog = null;
-	private List<String> acceptedList = new ArrayList<String>();
+    private File rejectLog = null;
+    private File acceptLog = null;
+    private File updateLog = null;
+    private List<String> acceptedList = new ArrayList<String>();
     private DAOFactory daoFactory;
-	private boolean ingestAsDanica;
-	private boolean onlysavestats;
-	
-	public LoadSeeds(File seedsfile, boolean acceptSeedsAsDanica) {
-	   this.seedsfile = seedsfile;
-	   this.daoFactory = DatabaseUtils.getDao();
-	   this.ingestAsDanica = acceptSeedsAsDanica;
+    private boolean ingestAsDanica;
+    private boolean onlysavestats;
+
+    public LoadSeeds(File seedsfile, boolean acceptSeedsAsDanica) {
+        this.seedsfile = seedsfile;
+        this.daoFactory = DatabaseUtils.getDao();
+        this.ingestAsDanica = acceptSeedsAsDanica;
     }
-	
-	/**
-	 * @return the ingestLog for the file just processed
-	 * @throws Exception 
-	 */
-	public IngestLog processSeeds() {
-		SeedsDAO dao = daoFactory.getSeedsDAO();
-		DomainsDAO ddao = daoFactory.getDomainsDAO();
-		String line;
-        long linecount=0L;
-        long insertedcount=0L;
-        long rejectedcount=0L;
-        long duplicatecount=0L;
-        String trimmedLine = null;
-        String url = null;
-        BufferedReader fr = null;
+
+    /**
+     * @return the ingestLog for the file just processed
+     */
+    public IngestLog processSeeds() {
+        long insertedcount = 0L;
+        long rejectedcount = 0L;
+        long duplicatecount = 0L;
+
         List<String> logentries = new ArrayList<String>();
         List<String> updatelogentries = new ArrayList<String>();
         List<String> domainLogentries = new ArrayList<String>();
+
         long lines = 0;
-        try {
-        	fr = new BufferedReader(new FileReader(seedsfile));
-	        while ((line = fr.readLine()) != null) {
-	            trimmedLine = line.trim();
 
-	            ++lines;
-	            if (lines % 10000 == 0) {
-	            	System.out.println("Processed " + lines + " seeds.");
-	            }
+        try (BufferedReader fr = new BufferedReader(new FileReader(seedsfile))) {
 
-	            trimmedLine = removeAnnotationsIfNecessary(trimmedLine);
-	            url = trimmedLine;
-	            linecount++;
-	            URL_REJECT_REASON rejectreason = UrlUtils.isRejectableURL(url);
-	            String errMsg = "";
-	            if (rejectreason == URL_REJECT_REASON.NONE) {
-	            	Seed singleSeed = new Seed(url);
-	            	if (ingestAsDanica) {
-	            		singleSeed.setDanicaStatus(DanicaStatus.YES);
-	            		singleSeed.setDanicaStatusReason("Known by curators to be danica");
-	            		singleSeed.setStatus(Status.DONE);
-	            		singleSeed.setStatusReason("Set to Status done at ingest to prevent further processing of this url");
-	            	}
-	            	boolean inserted = false;
-	            	boolean isError = false;
-	            	try {
-	            	    inserted = dao.insertSeed(singleSeed);
-	            	    
-	            	    if (inserted) {
-	            	    	String domainName = singleSeed.getDomain();
-	            	    	if (!ddao.existsDomain(domainName)) {
-	            	    		Domain newdomain = Domain.createNewUndecidedDomain(domainName);
-	            	    		boolean insertedDomain = ddao.insertDomain(newdomain);
-	            	    		if (!insertedDomain) {
-	            	    			domainLogentries.add("Failed to add domain '" + domainName + "' to domains table, the domain of seed '" + url + "'");
-	            	    		} else {
-	            	    			domainLogentries.add("Added domain '" + domainName + "' to domains table, the domain of seed '" + url + "'");
-	            	    		}
-	            	    	}
-	            	    }
-	            	} catch (Throwable e) {
-	            	    rejectreason = URL_REJECT_REASON.BAD_URL;
-	            	    errMsg = "Insertion of url failed: " + e.toString();
-	            	}
-	            	
-	            	if (!inserted && !isError) { // assume duplicate url
-	            		if (ingestAsDanica) {
-	            			// update state of seed if not already in Status.DONE 
-	            			Seed oldSeed = dao.getSeed(url);
-	            			if (oldSeed == null) {
-	            				// Should not happen
-	            				rejectreason = URL_REJECT_REASON.UNKNOWN;
-	            				errMsg = "The url '" + url + "' should have been in database. But no record was found";
-	            			} else {
-	            				if (oldSeed.getDanicaStatus().equals(DanicaStatus.YES)) {
-	            					updatelogentries.add("The seed '" + url + "' is already in the database with DanicaStatus.YES and status '" + oldSeed.getStatus() + "'");
-	            				} else {
-	            					updatelogentries.add("The seed '" + url + "' is already in the database with DanicaStatus=" + oldSeed.getDanicaStatus() + ", and status '" +
-	            							oldSeed.getStatus() + "'. Changing to DanicaStatus.YES and status.DONE");
-	            					oldSeed.setDanicaStatus(DanicaStatus.YES);
-	            					oldSeed.setDanicaStatusReason("Known by curators to be danica");
-	            					oldSeed.setStatus(Status.DONE);
-	            					oldSeed.setStatusReason("Set to Status done at ingest to prevent further processing of this url");
-	            					dao.updateSeed(oldSeed);
-	            				}
-	            			}
-	            		} else {
-	            			rejectreason = URL_REJECT_REASON.DUPLICATE;
-	            			duplicatecount++;
-	            		}
-	            	} else if(inserted) { 
-	            		insertedcount++;
-	            		if (!onlysavestats) {
-	            			acceptedList.add(url);
-	            		}
-	            	}
-	            }
-	            
-	            if (rejectreason != URL_REJECT_REASON.NONE) {
-	            	if (!onlysavestats) {
-	            		logentries.add(rejectreason + ": " + url + " " + errMsg);
-	            	}
-	            	rejectedcount++;
-	            }
-	            
-	        }
-	        
-	        // add the updatedLog to logentries
-	        for (String logUpdated: updatelogentries) {
-	        	logentries.add("UPDATED: " + logUpdated);
-	        }
-	        
-	        // add the domains to logentries
-	        for (String logUpdated: domainLogentries) {
-	        	logentries.add("DOMAINS: " + logUpdated);
-	        }
-	        
-	        // write accept-log
-	        if (writeAcceptLog) {
-	        	acceptLog = new File(seedsfile.getParentFile(), seedsfile.getName() + ".accepted.txt");
-	        	int count=0;
-	        	while (acceptLog.exists()) {
-	        		acceptLog = new File(seedsfile.getParentFile(), seedsfile.getName() + ".accepted.txt" + "." + count);
-	        		count++;
-	        	} 
-	        	PrintWriter acceptWriter = new PrintWriter(new BufferedWriter(new FileWriter(acceptLog)));
-	        	String acceptHeader = "Acceptlog for file '" + seedsfile.getAbsolutePath() + "' ingested at '" 
-	        			+ new Date() + "'";
-	        	String stats = "total lines: " + linecount + ", accepted = " + insertedcount + ", rejected=" + rejectedcount 
-	        			+ " (of which " + duplicatecount + " duplicates";
-	        	acceptWriter.println(acceptHeader);
-	        	acceptWriter.println(stats);
-	        	if (!acceptedList.isEmpty()) {
-	        		acceptWriter.println("The " + insertedcount + " accepted :");
-	        		for (String acc: acceptedList) {
-	        			acceptWriter.println(acc);
-	        		} 
-	        	} else {
-	        		if (!onlysavestats) {
-	        			acceptWriter.println("None were accepted!");
-	        		}
-	        	}
-	        	
-	        	acceptWriter.close();
-	        }
-	        
-	        // write reject-log
-	        if (writeRejectLog) {
-	        	rejectLog = new File(seedsfile.getParentFile(), seedsfile.getName() + ".rejected.txt");
-	        	int count=0;
-	        	while (rejectLog.exists()) {
-	        		rejectLog = new File(seedsfile.getParentFile(), seedsfile.getName() + ".rejected.txt" + "." + count);
-	        		count++;
-	        	}
-	        	PrintWriter rejectWriter = new PrintWriter(new BufferedWriter(new FileWriter(rejectLog)));
-	        	String rejectHeader = "Rejectlog for file '" + seedsfile.getAbsolutePath() + "' ingested at '" 
-	        			+ new Date() + "'";
-	        	String stats = "total lines: " + linecount + ", accepted = " + insertedcount + ", rejected=" + rejectedcount 
-	        			+ " (of which " + duplicatecount + " duplicates";
-	        	rejectWriter.println(rejectHeader);
-	        	rejectWriter.println(stats);
-	        	if (!onlysavestats) {
-	        		rejectWriter.println("Rejected seeds:");
-	        		for (String rej: logentries) {
-	        			rejectWriter.println(rej);
-	        		}
-	        	}
-	        	rejectWriter.close();
-	        }
-	        
-	     // write update-log
-	        if (writeUpdateLog) {
-	        	updateLog = new File(seedsfile.getParentFile(), seedsfile.getName() + ".updated.txt");
-	        	int count=0;
-	        	while (updateLog.exists()) {
-	        		updateLog = new File(seedsfile.getParentFile(), seedsfile.getName() + ".updated.txt" + "." + count);
-	        		count++;
-	        	}
-	        	PrintWriter updatedWriter = new PrintWriter(new BufferedWriter(new FileWriter(updateLog)));
-	        	String updatedHeader = "Update and domain Log for file '" + seedsfile.getAbsolutePath() + "' ingested at '" 
-	        			+ new Date() + "'";
-	        	updatedWriter.println(updatedHeader);
-	        	updatedWriter.println();
-	        	if (!updatelogentries.isEmpty()) {
-	        		updatedWriter.println("Update - entries:");
-	        		for (String rej: updatelogentries) {
-	        			updatedWriter.println(rej);
-	        		}
-	        	}
-	        	if (!domainLogentries.isEmpty()) {
-	        		updatedWriter.println("domain-log - entries:");
-	        		for (String rej: domainLogentries) {
-	        			updatedWriter.println(rej);
-	        		}
-	        	}
-	        	updatedWriter.close();
-	        }
-	          
-	        
-	        
-        } catch (Throwable e) {
-	        e.printStackTrace();
-        } finally {
-        	IOUtils.closeQuietly(fr);
-        	dao.close();
+            String line;
+            while ((line = fr.readLine()) != null) {
+                ++lines;
+                if (lines % 10000 == 0) {
+                    logger.info("Processed {} seeds.", lines);
+                }
+
+                String errMsg = "";
+                String url = removeAnnotationsIfNecessary(line.trim());
+
+                URL_REJECT_REASON rejectreason = UrlUtils.isRejectableURL(url);
+
+                if (rejectreason == URL_REJECT_REASON.NONE) {
+                    Seed singleSeed = new Seed(url);
+                    if (ingestAsDanica) {
+                        singleSeed.setDanicaStatus(DanicaStatus.YES);
+                        singleSeed.setDanicaStatusReason("Known by curators to be danica");
+                        singleSeed.setStatus(Status.DONE);
+                        singleSeed.setStatusReason("Set to Status done at ingest to prevent further processing of this url");
+                    }
+
+
+                    try (SeedsDAO dao = daoFactory.getSeedsDAO();
+                         DomainsDAO ddao = daoFactory.getDomainsDAO();) {
+
+                        boolean inserted;
+                        inserted = dao.insertSeed(singleSeed);
+
+                        if (inserted) {
+                            String domainName = singleSeed.getDomain();
+                            if (!ddao.existsDomain(domainName)) {
+                                Domain newdomain = Domain.createNewUndecidedDomain(domainName);
+                                boolean insertedDomain = ddao.insertDomain(newdomain);
+                                if (!insertedDomain) {
+                                    domainLogentries.add("Failed to add domain '" + domainName + "' to domains table, the domain of seed '" + url + "'");
+                                } else {
+                                    domainLogentries.add("Added domain '" + domainName + "' to domains table, the domain of seed '" + url + "'");
+                                }
+                            }
+                            insertedcount++;
+                            if (!onlysavestats) {
+                                acceptedList.add(url);
+                            }
+
+                        } else {
+                            if (ingestAsDanica) {
+                                // update state of seed if not already in Status.DONE
+                                Seed oldSeed = dao.getSeed(url);
+                                if (oldSeed == null) {
+                                    // Should not happen
+                                    rejectreason = URL_REJECT_REASON.UNKNOWN;
+                                    logger.warn("The url '{}' should have been in database. But no record was found", url);
+                                    errMsg = "The url '"+url+"' should have been in database. But no record was found";
+                                } else {
+                                    if (oldSeed.getDanicaStatus().equals(DanicaStatus.YES)) {
+                                        updatelogentries.add("The seed '" + url + "' is already in the database with DanicaStatus.YES and status '" + oldSeed.getStatus() + "'");
+                                    } else {
+                                        updatelogentries.add("The seed '" + url + "' is already in the database with DanicaStatus=" + oldSeed.getDanicaStatus() + ", and status '" +
+                                                oldSeed.getStatus() + "'. Changing to DanicaStatus.YES and status.DONE");
+                                        oldSeed.setDanicaStatus(DanicaStatus.YES);
+                                        oldSeed.setDanicaStatusReason("Known by curators to be danica");
+                                        oldSeed.setStatus(Status.DONE);
+                                        oldSeed.setStatusReason("Set to Status done at ingest to prevent further processing of this url");
+                                        dao.updateSeed(oldSeed);
+                                    }
+                                }
+                            } else {
+                                rejectreason = URL_REJECT_REASON.DUPLICATE;
+                                duplicatecount++;
+                            }
+                        }
+                    } catch (DaoException e) {
+                        logger.error("Failure in communication with HBase",e);
+                        rejectreason = URL_REJECT_REASON.UNKNOWN;
+                        errMsg = "Failure in communication with HBase: "+e.toString();
+                    }
+
+                    if (rejectreason != URL_REJECT_REASON.NONE) {
+                        if (!onlysavestats) {
+                            logentries.add(rejectreason + ": " + url + " " + errMsg);
+                        }
+                        rejectedcount++;
+                    }
+                }
+
+                // add the updatedLog to logentries
+                for (String logUpdated : updatelogentries) {
+                    logentries.add("UPDATED: " + logUpdated);
+                }
+
+                // add the domains to logentries
+                for (String logUpdated : domainLogentries) {
+                    logentries.add("DOMAINS: " + logUpdated);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read file " + seedsfile, e);
         }
-        
-	    IngestLog logresult = null;
-        try {
-            logresult = logIngestStats(logentries, linecount, insertedcount, rejectedcount, duplicatecount);
-        } catch (Exception e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        } 
-	    return logresult;
-	}
 
-	private String removeAnnotationsIfNecessary(String trimmedLine) {
-	    String[] trimmedParts = trimmedLine.split(" ");
-	    if (trimmedParts.length > 1) {
-	    	return trimmedParts[0];
-	    } else {
-	    	return trimmedLine;
-	    }
+        try {
+            writeAcceptLog(insertedcount, rejectedcount, duplicatecount, lines);
+            writeRejectLog(insertedcount, rejectedcount, duplicatecount, logentries, lines);
+            writeUpdateLog(updatelogentries, domainLogentries);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write logs", e);
+        }
+
+        try {
+            return logIngestStats(logentries, lines, insertedcount, rejectedcount, duplicatecount);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to log ingest stats",e);
+        }
+
     }
 
-	private IngestLog logIngestStats(List<String> logentries, long linecount, long insertedcount, long rejectedcount, long duplicatecount) throws Exception {
-		IngestLogDAO dao = null;
-		try {
-			dao = daoFactory.getIngestLogDAO();
-			IngestLog log = new IngestLog(logentries, seedsfile.getName(), linecount, insertedcount, rejectedcount, duplicatecount);
-			dao.insertLog(log);
-			return log;
-		} finally {
-			dao.close();
-		}
-	}
-	
-	File getRejectLog() {
-		return this.rejectLog;
-	}
-	
-	File getAcceptLog() {
-		return this.acceptLog;
-	}
-	
-	File getUpdateLog() {
-		return this.updateLog;
-	}
+
+
+    private void writeUpdateLog(List<String> updatelogentries, List<String> domainLogentries) throws
+            IOException {
+        // write update-log
+        if (writeUpdateLog) {
+            updateLog = new File(seedsfile.getParentFile(), seedsfile.getName() + ".updated.txt");
+            int count = 0;
+            while (updateLog.exists()) {
+                updateLog = new File(seedsfile.getParentFile(), seedsfile.getName() + ".updated.txt" + "." + count);
+                count++;
+            }
+            try (PrintWriter updatedWriter = new PrintWriter(new BufferedWriter(new FileWriter(updateLog)))) {
+                String updatedHeader = "Update and domain Log for file '" + seedsfile.getAbsolutePath() + "' ingested at '"
+                        + new Date() + "'";
+                updatedWriter.println(updatedHeader);
+                updatedWriter.println();
+                if (!updatelogentries.isEmpty()) {
+                    updatedWriter.println("Update - entries:");
+                    for (String rej : updatelogentries) {
+                        updatedWriter.println(rej);
+                    }
+                }
+                if (!domainLogentries.isEmpty()) {
+                    updatedWriter.println("domain-log - entries:");
+                    for (String rej : domainLogentries) {
+                        updatedWriter.println(rej);
+                    }
+                }
+            }
+        }
+    }
+
+    private void writeRejectLog(long insertedcount, long rejectedcount, long duplicatecount, List<
+            String> logentries, long lines) throws IOException {
+        // write reject-log
+        if (writeRejectLog) {
+            rejectLog = new File(seedsfile.getParentFile(), seedsfile.getName() + ".rejected.txt");
+            int count = 0;
+            while (rejectLog.exists()) {
+                rejectLog = new File(seedsfile.getParentFile(), seedsfile.getName() + ".rejected.txt" + "." + count);
+                count++;
+            }
+            try (PrintWriter rejectWriter = new PrintWriter(new BufferedWriter(new FileWriter(rejectLog)))) {
+
+                String rejectHeader = "Rejectlog for file '" + seedsfile.getAbsolutePath() + "' ingested at '"
+                        + new Date() + "'";
+                String stats = "total lines: " + lines + ", accepted = " + insertedcount + ", rejected=" + rejectedcount
+                        + " (of which " + duplicatecount + " duplicates";
+                rejectWriter.println(rejectHeader);
+                rejectWriter.println(stats);
+                if (!onlysavestats) {
+                    rejectWriter.println("Rejected seeds:");
+                    for (String rej : logentries) {
+                        rejectWriter.println(rej);
+                    }
+                }
+            }
+
+        }
+    }
+
+    private void writeAcceptLog(long insertedcount, long rejectedcount, long duplicatecount, long lines) throws
+            IOException {
+        // write accept-log
+        if (writeAcceptLog) {
+            acceptLog = new File(seedsfile.getParentFile(), seedsfile.getName() + ".accepted.txt");
+            int count = 0;
+            while (acceptLog.exists()) {
+                acceptLog = new File(seedsfile.getParentFile(), seedsfile.getName() + ".accepted.txt" + "." + count);
+                count++;
+            }
+            try (PrintWriter acceptWriter = new PrintWriter(new BufferedWriter(new FileWriter(acceptLog)))) {
+                String acceptHeader = "Acceptlog for file '" + seedsfile.getAbsolutePath() + "' ingested at '"
+                        + new Date() + "'";
+                String stats = "total lines: " + lines + ", accepted = " + insertedcount + ", rejected=" + rejectedcount
+                        + " (of which " + duplicatecount + " duplicates";
+                acceptWriter.println(acceptHeader);
+                acceptWriter.println(stats);
+                if (!acceptedList.isEmpty()) {
+                    acceptWriter.println("The " + insertedcount + " accepted :");
+                    for (String acc : acceptedList) {
+                        acceptWriter.println(acc);
+                    }
+                } else {
+                    if (!onlysavestats) {
+                        acceptWriter.println("None were accepted!");
+                    }
+                }
+            }
+
+        }
+    }
+
+    private String removeAnnotationsIfNecessary(String trimmedLine) {
+        String[] trimmedParts = trimmedLine.split(" ");
+        if (trimmedParts.length > 1) {
+            return trimmedParts[0];
+        } else {
+            return trimmedLine;
+        }
+    }
+
+    private IngestLog logIngestStats(List<String> logentries, long linecount, long insertedcount,
+                                     long rejectedcount, long duplicatecount) throws Exception {
+        IngestLogDAO dao = null;
+        try {
+            dao = daoFactory.getIngestLogDAO();
+            IngestLog log = new IngestLog(logentries, seedsfile.getName(), linecount, insertedcount, rejectedcount, duplicatecount);
+            dao.insertLog(log);
+            return log;
+        } finally {
+            dao.close();
+        }
+    }
+
+    File getRejectLog() {
+        return this.rejectLog;
+    }
+
+    File getAcceptLog() {
+        return this.acceptLog;
+    }
+
+    File getUpdateLog() {
+        return this.updateLog;
+    }
 }

--- a/webdanica-core/src/main/java/dk/kb/webdanica/core/utils/CloseUtils.java
+++ b/webdanica-core/src/main/java/dk/kb/webdanica/core/utils/CloseUtils.java
@@ -1,0 +1,22 @@
+package dk.kb.webdanica.core.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by abr on 8/3/17.
+ */
+public class CloseUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(CloseUtils.class);
+
+    public static void closeQuietly(AutoCloseable autoCloseable){
+        if (autoCloseable != null) {
+            try {
+                autoCloseable.close();
+            } catch (Exception e) {
+                logger.warn("Caught Exception when closing {}", autoCloseable, e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
DAO klasserne kaster nu ikke bare random eller ingen exceptions. De kaster DaoException, som betyder at noget er fejlet. Det er mostly en wrapper for SQLException, men det kan være andet for andre backends.

Pom filen inkluderer nu hvad jeg tror er de rigtige hadoop dependencies.

Ændrede en Resolver test så den virkede, check lige om det er ønsket.

Brug slf4j til logning af fejl i Loadseeds

Java 7 Try-with-resources notation til at undgå alt for mange linier med close af resourcer